### PR TITLE
timeZone issue, just remove that

### DIFF
--- a/app/src/components/pages/ScheduleTimetable.tsx
+++ b/app/src/components/pages/ScheduleTimetable.tsx
@@ -12,7 +12,6 @@ function ScheduleTimetable() {
   const calendarData = parseCalendarJSON(JSON.parse(JSON.stringify(classData)));
   return (
     <Scheduler
-      timeZone="Canada/Pacific"
       dataSource={calendarData}
       defaultCurrentView="day"
       defaultCurrentDate={currentDate}


### PR DESCRIPTION
Changes
---
Remove "timeZone="Canada/Pacific" from ScheduleTimetable.tsx, and use the default timezone to display the correct time.

Testing
---
N/A

Linked Issue
---
https://github.com/SENG499-Company-4/Frontend/issues/55