### PR TITLE
Scheduler Route Parameters

### DIFF
--- a/app/src/components/pages/ProfessorProfile.tsx
+++ b/app/src/components/pages/ProfessorProfile.tsx
@@ -117,7 +117,7 @@ function ProfessorProfile() {
                     onClick={() => {
                       navigate('/schedule/timetable', {
                         state: {
-                          course
+                          courseId: course.CourseID.subject + course.CourseID.code
                         }
                       });
                     }}

--- a/app/src/components/pages/ProfessorsList.tsx
+++ b/app/src/components/pages/ProfessorsList.tsx
@@ -2,28 +2,52 @@ import React from 'react';
 import { DataGrid, GridColDef } from '@mui/x-data-grid';
 import { parseCalendarTeacher } from 'utils/utils';
 import classData from 'data/clean.json';
-import { Box } from '@mui/material';
+import { Box, ButtonBase } from '@mui/material';
 import SearchIcon from '@mui/icons-material/Search';
 import { Search, SearchIconWrapper, StyledInputBase } from 'components/styles/styles';
 import { useState } from 'react';
 import { ICalendarItem_Teacher } from 'components/shared/interfaces/timetable.interfaces';
 import Link from '@mui/material/Link';
-
-const columns: GridColDef[] = [
-  { field: 'id', headerName: 'ID', width: 70 },
-  { field: 'teacherName', headerName: 'Username', width: 130 },
-  {
-    field: 'link',
-    headerName: 'View Professor Profile',
-    width: 200,
-    renderCell: (params: any) => <Link href={params.value}> View profile </Link>
-  }
-];
+import { NavigateFunction, useNavigate } from 'react-router-dom';
 
 function ProfessorsList() {
   const allData: ICalendarItem_Teacher[] = parseCalendarTeacher(JSON.parse(JSON.stringify(classData)));
   const [search, setSearch] = useState<string>('');
   const [rows, setRows] = useState<ICalendarItem_Teacher[]>(allData);
+  const navigate: NavigateFunction = useNavigate();
+
+  const columns: GridColDef[] = [
+    { field: 'id', headerName: 'ID', width: 70 },
+    { field: 'teacherName', headerName: 'Username', width: 130 },
+    { field: 'faculty', headerName: 'Faculty', width: 100 },
+    {
+      field: 'link',
+      headerName: 'View Professor Profile',
+      width: 200,
+      renderCell: (params) => <Link href={params.value}> View profile </Link>
+    },
+    {
+      field: 'courses',
+      headerName: 'Currently Teaching',
+      width: 300,
+      renderCell: (params) => {
+        console.log('params', params);
+        return (
+          <ButtonBase
+            onClick={() => {
+              navigate('/schedule/timetable', {
+                state: {
+                  professorId: params.row.id
+                }
+              });
+            }}
+          >
+            <Link>View Coures</Link>
+          </ButtonBase>
+        );
+      }
+    }
+  ];
 
   function filter(data: ICalendarItem_Teacher[], search: string) {
     var newData: ICalendarItem_Teacher[] = [];

--- a/app/src/components/pages/ProfessorsList.tsx
+++ b/app/src/components/pages/ProfessorsList.tsx
@@ -42,7 +42,7 @@ function ProfessorsList() {
               });
             }}
           >
-            <Link>View Coures</Link>
+            <Link>View Courses</Link>
           </ButtonBase>
         );
       }

--- a/app/src/components/pages/ProfessorsList.tsx
+++ b/app/src/components/pages/ProfessorsList.tsx
@@ -24,7 +24,10 @@ function ProfessorsList() {
       field: 'link',
       headerName: 'View Professor Profile',
       width: 200,
-      renderCell: (params) => <Link href={params.value}> View profile </Link>
+      renderCell: (params) => {
+        console.log('PARAMS: ', params);
+        return <Link href={'/professor-profile/' + params.id}> View profile </Link>;
+      }
     },
     {
       field: 'courses',

--- a/app/src/components/pages/ScheduleTimetable.tsx
+++ b/app/src/components/pages/ScheduleTimetable.tsx
@@ -8,6 +8,7 @@ import { parseCalendarCourse, parseCalendarTeacher } from 'utils/utils';
 // import { useLocation } from 'react-router-dom';
 import { Button, Box } from '@mui/material';
 import { Location, useLocation } from 'react-router-dom';
+import { Chip } from '@mui/material';
 
 //The current date will be +1 month in the UI, ex: 2021/Dec/10 -> 2022/Jan/10
 const currentDate = new Date(2021, 12, 10);
@@ -38,6 +39,24 @@ function ScheduleTimetable() {
           Save
         </Button>
       </Box>
+      {professorId && (
+        <Chip
+          color="primary"
+          label={'Filtered by Professor: ' + professorId}
+          sx={{
+            margin: '10px'
+          }}
+        />
+      )}
+      {courseId && (
+        <Chip
+          color="primary"
+          label={'Filtered by Course: ' + courseId}
+          sx={{
+            margin: '10px'
+          }}
+        />
+      )}
       {/*@ts-ignore*/}
       <Scheduler
         timeZone="Canada/Pacific"
@@ -63,7 +82,7 @@ function ScheduleTimetable() {
         showAllDayPanel={false}
         editingAppointment={false}
       >
-        <Editing allowAdding={false} allowDragging={false} />
+        <Editing allowAdding={false} allowDragging={true} />
         <Resource
           dataSource={calendarTeacherData}
           fieldExpr="teacherId"

--- a/app/src/components/pages/ScheduleTimetable.tsx
+++ b/app/src/components/pages/ScheduleTimetable.tsx
@@ -7,20 +7,25 @@ import { parseCalendarCourse, parseCalendarTeacher } from 'utils/utils';
 // import { ICourse } from 'components/shared/interfaces/timetable.interfaces';
 // import { useLocation } from 'react-router-dom';
 import { Button, Box } from '@mui/material';
+import { Location, useLocation } from 'react-router-dom';
 
 //The current date will be +1 month in the UI, ex: 2021/Dec/10 -> 2022/Jan/10
 const currentDate = new Date(2021, 12, 10);
 
-// interface IStateProps {
-//   course: ICourse;
-// }
+interface IStateProps {
+  courseId?: string;
+  professorId?: number;
+}
 
 function ScheduleTimetable() {
-  const calendarCourseData = parseCalendarCourse(JSON.parse(JSON.stringify(classData)));
-  const calendarTeacherData = parseCalendarTeacher(JSON.parse(JSON.stringify(classData)));
+  const location: Location = useLocation();
+  const state: IStateProps = location.state as IStateProps;
+  console.log('Location: ', location);
+  const courseId = state?.courseId ? state.courseId : undefined;
+  const professorId = state?.professorId ? state.professorId : undefined;
 
-  // const { state } = useLocation();
-  // const { course } = state as IStateProps;
+  let calendarCourseData = parseCalendarCourse(JSON.parse(JSON.stringify(classData)), courseId, professorId);
+  let calendarTeacherData = parseCalendarTeacher(JSON.parse(JSON.stringify(classData)));
 
   function exportState() {
     console.log(calendarCourseData);
@@ -50,7 +55,7 @@ function ScheduleTimetable() {
             maxAppointmentsPerCell: 2
           }
         ]}
-        defaultCurrentView="day"
+        defaultCurrentView="week"
         defaultCurrentDate={currentDate}
         startDayHour={8}
         height={800}

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -24,8 +24,11 @@ export function parseCalendarTeacher(data: ICourse[]): ICalendarItem_Teacher[] {
   return calendarTeacherData;
 }
 
-export function parseCalendarCourse(data: ICourse[]): ICalendarCourseItem[] {
+export function parseCalendarCourse(data: ICourse[], courseId?: string, professorId?: number): ICalendarCourseItem[] {
   const calendarCourseData: ICalendarCourseItem[] = [];
+  let courseProp = courseId ? courseId : undefined;
+  let professorProp = professorId ? professorId : undefined;
+
   data.forEach((course: ICourse) => {
     course.meetingTimes.forEach((element) => {
       //each meeting maps to a calendar item ex: csc105 has three calendar items: Tus, Wed, Fri.
@@ -49,7 +52,27 @@ export function parseCalendarCourse(data: ICourse[]): ICalendarCourseItem[] {
         // And if you click same course on Wednesday, it will show repeat on Wed.
         recurrenceRule: 'FREQ=WEEKLY;BYDAY=' + element.Day.slice(0, 2) + ';UNTIL=' + course.endDate.replaceAll('-', '')
       };
-      calendarCourseData.push(calendarItem);
+
+      // Conditional return rules based on props
+      if (professorProp && courseProp) {
+        console.log('Have professor and course props', professorProp, courseProp);
+        if (calendarItem.teacherId === professorProp && courseProp === calendarItem.courseId) {
+          calendarCourseData.push(calendarItem);
+        }
+      } else if (courseProp && !professorProp) {
+        console.log('Have course props', professorProp, courseProp);
+        if (calendarItem.courseId === courseProp) {
+          calendarCourseData.push(calendarItem);
+        }
+      } else if (!courseProp && professorProp) {
+        console.log('Have professor props', professorProp, courseProp);
+        if (calendarItem.teacherId === professorProp) {
+          calendarCourseData.push(calendarItem);
+        }
+      } else {
+        console.log('No props', professorProp, courseProp);
+        calendarCourseData.push(calendarItem);
+      }
     });
   });
   return calendarCourseData;

--- a/app/src/utils/utils.ts
+++ b/app/src/utils/utils.ts
@@ -55,22 +55,18 @@ export function parseCalendarCourse(data: ICourse[], courseId?: string, professo
 
       // Conditional return rules based on props
       if (professorProp && courseProp) {
-        console.log('Have professor and course props', professorProp, courseProp);
         if (calendarItem.teacherId === professorProp && courseProp === calendarItem.courseId) {
           calendarCourseData.push(calendarItem);
         }
       } else if (courseProp && !professorProp) {
-        console.log('Have course props', professorProp, courseProp);
         if (calendarItem.courseId === courseProp) {
           calendarCourseData.push(calendarItem);
         }
       } else if (!courseProp && professorProp) {
-        console.log('Have professor props', professorProp, courseProp);
         if (calendarItem.teacherId === professorProp) {
           calendarCourseData.push(calendarItem);
         }
       } else {
-        console.log('No props', professorProp, courseProp);
         calendarCourseData.push(calendarItem);
       }
     });

--- a/app/tsconfig.json
+++ b/app/tsconfig.json
@@ -18,6 +18,7 @@
     "declaration": true, // Generate corresponding .d.ts file
     "noUnusedLocals": true, // Report errors on unused locals
     "noUnusedParameters": true, // Report errors on unused parameters
+    "noUnusedVariables": false, // Report errors on unused variables
     "incremental": true, // Enable incremental compilation by reading/writing information from prior compilations to a file on disk
     "noFallthroughCasesInSwitch": true, // Report errors for fallthrough cases in switch statement
     "baseUrl": "src" // Base directory of the app for resolving relative paths (instead of "../../src/App.tsx", use "src/App.tsx")


### PR DESCRIPTION
Changes
---
* Added route parameters to schedule page that dictate what the scheduler will show
* Default: No parameters (show schedule as default with all courses)
* Navigate from professor list --> Show courses that professor is teaching
* Navigate from professor page --> Show all time slots for that course

Testing
---
* Extremely rigorous, very careful manual testing

Linked Issue
---
* #76 
* #77 

Additional Info
---
* Stretch goal: Have props mutate some filter element of the schedule rather than directly changing the schedule (right now the only way to revisit the original schedule is to navigate away and then back, or refresh the page. Not a big deal.)
